### PR TITLE
Fixing missing header for std::sqrt.

### DIFF
--- a/xbrz/xbrz.cpp
+++ b/xbrz/xbrz.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <algorithm>
 #include <vector>
+#include <cmath>
 
 namespace
 {


### PR DESCRIPTION
I wasn't able to compile with the GNU compiler. Apparently the header to import `std::sqrt`, `<cmath>` was missing.