### PR TITLE
Improved library performance by caching the internal image data,

### DIFF
--- a/libxbrzscale.h
+++ b/libxbrzscale.h
@@ -23,13 +23,25 @@ struct SDL_Surface;
 class libxbrzscale
 {
  public:
-  static inline Uint32 SDL_GetPixel(SDL_Surface *surface, int x, int y);
-  static inline void SDL_PutPixel(SDL_Surface *surface, int x, int y, Uint32 pixel);
+  static Uint32 SDL_GetPixel(SDL_Surface *surface, int x, int y);
+  static void SDL_PutPixel(SDL_Surface *surface, int x, int y, Uint32 pixel);
   static SDL_Surface* createARGBSurface(int w, int h);
   static SDL_Surface* scale(SDL_Surface* src_img,int scale);
-  static void setEnableOutput(bool b){bEnableOutput=true;};
+  static SDL_Surface* scale(SDL_Surface* dst_imgCache,SDL_Surface* src_img,int scale);
+  static void setEnableOutput(bool b){bEnableOutput=b;};
+  static void setDebugMsg(bool b){bDbgMsg=b;};
+  static void setFreeSurfaceAfterScale(bool bInputSurface,bool bOutputSurface){
+    bFreeInputSurfaceAfterScale=bInputSurface;
+    bFreeOutputSurfaceAfterScale=bOutputSurface;
+  };
+  static void setUseCache(bool b){bUseCache=b;};
   static uint32_t* surfaceToUint32(SDL_Surface* img);
   static void uint32toSurface(uint32_t* dest, SDL_Surface* dst_img);
+  static bool isDbgMsg(){return bDbgMsg;}
  private:
   static bool bEnableOutput;
+  static bool bDbgMsg;
+  static bool bUseCache;
+  static bool bFreeInputSurfaceAfterScale;
+  static bool bFreeOutputSurfaceAfterScale;
 };


### PR DESCRIPTION
this way, instead of delete (free) the image data memory,
if it matches the requirements (WxH) that cached data will be re-used.

By not trying to free memory, therefore not requiring to allocate new
memory, it is easier on the OS.

As a practical result, it avoids slowness and memory swapping to HD.

Obs.: I removed the 'inline' modifier for 2 methods at libxbrzscale.h, not sure if they are necessary to improve in some way the code, but were causing compile problems.